### PR TITLE
Added ability to exclude multiple directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Set a path and filename here to write to a file, otherwise it will write to stdo
 Type: `String`
 Default: `false`
 
-Exclude <dir> from code analysis.
+Exclude `<dir>` from code analysis.  Also supports `Array` syntax for excluding multiple directories.
 
 #### minLines
 Type: `Number`

--- a/tasks/lib/phpcpd.coffee
+++ b/tasks/lib/phpcpd.coffee
@@ -9,6 +9,8 @@ Licensed under the BSD license.
 path = require 'path'
 exec = (require 'child_process').exec
 
+typeIsArray = Array.isArray || ( value ) -> return {}.toString.call( value ) is '[object Array]'
+
 exports.init = (grunt) ->
 
   exports = config = {}
@@ -30,7 +32,13 @@ exports.init = (grunt) ->
     cmd += " --log-pmd #{config.reportFile}" if config.reportFile
     cmd += " --min-lines #{config.minLines}"
     cmd += " --min-tokens #{config.minTokens}"
-    cmd += " --exclude #{config.exclude}" if config.exclude
+
+    if typeIsArray config.exclude
+      cmd += " --exclude #{excl}" for excl in config.exclude
+    else if config.exclude
+      cmd += " --exclude #{config.exclude}"
+
+
     cmd += " --names \"#{config.names}\"" if config.names
     cmd += " --quiet" if config.quiet
     cmd += " --verbose" if config.verbose


### PR DESCRIPTION
Current implementation doesn't support the syntax for excluding multiple directories.  You have to do nasty things like

```
exclude: 'staticlibrary --exclude lib-test --exclude sharedlib-test --exclude sharedmodules-test'
```

This adds the ability to provide an array of paths to ignore, and is backwards compatible with the existing string syntax.
