### PR TITLE
Added --fuzzy option to allow for fuzz variable names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Default: `70`
 
 Minimum number of identical tokens.
 
+#### fuzzy
+Type: `Boolean`
+Default: `false`
+
+Use fuzz variable names.
+
 #### names
 Type: `String`
 Default: `'*.php'`

--- a/tasks/lib/phpcpd.coffee
+++ b/tasks/lib/phpcpd.coffee
@@ -20,6 +20,7 @@ exports.init = (grunt) ->
     bin: 'phpcpd'
     minLines: 5
     minTokens: 70
+    fuzzy: false
     exclude: false
     names: '*.php'
     quiet: true
@@ -33,6 +34,7 @@ exports.init = (grunt) ->
     cmd += " --log-pmd #{config.reportFile}" if config.reportFile
     cmd += " --min-lines #{config.minLines}"
     cmd += " --min-tokens #{config.minTokens}"
+    cmd += " --fuzzy" if config.fuzzy
     if typeIsArray config.exclude
       cmd += " --exclude #{excl}" for excl in config.exclude
     else if config.exclude


### PR DESCRIPTION
PHPCPD has a very useful flag to allow for fuzzy variable name matching.
